### PR TITLE
Add docker ignores to database and __pycache__

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+./database
+**/__pycache__


### PR DESCRIPTION
I don't know if anyone has faced this issue but I have faced it on my Linux machine. This patch fixes the permission denied issue after trying to rebuild the container.