### PR TITLE
Add watch to poetry packages

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,5 +25,5 @@ services:
           ignore:
             - __pycache__/
         - action: rebuild
-          path: requirements.txt
+          path: pyproject.toml
 


### PR DESCRIPTION
When I was migrating to poetry I forgot to change the docker compose watch from `requirements.txt` to `pyproject.toml`... This patch is to add back the watch to poetry packages.