### PR TITLE
Add logs to junit reports and measure function calls

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,6 @@
 pythonpath = .
 addopts = -rA --ignore=database
 testpaths = tests
+junit_logging = log
+junit_log_passing_tests = true
+junit_duration_report = call

--- a/tests/test_availability.py
+++ b/tests/test_availability.py
@@ -1,10 +1,10 @@
 import re
 from datetime import datetime
 
-from conftest import TEST_DB_NAME
 from flask.testing import FlaskClient
 
 from flaskr.db.user import create_precreated_user, get_precreated_user
+from tests.conftest import TEST_DB_NAME
 from tests.utils import GetDatabase
 
 
@@ -37,7 +37,7 @@ def test_api_ping(client: FlaskClient):
     assert match_ is not None
     assert (
         datetime.strptime(match_.group(1), "%d-%m-%Y %H:%M:%S.%f").timestamp()
-        < datetime.now().timestamp()
+        <= datetime.now().timestamp()
     )
 
 


### PR DESCRIPTION
This pr extends `pytest.ini` to include more junit logging and make pytest meaure function calls instead of setup and teardowns. Also fixes a minor bug in the tests i encounted