### PR TITLE
Enhance license generation

### DIFF
--- a/flaskr/api/reqmodels.py
+++ b/flaskr/api/reqmodels.py
@@ -106,3 +106,11 @@ class CoursePlanUpdateRequestModel(BaseModel):
     description: Optional[str] = None
     favourite: Optional[bool] = None
     name: Optional[str] = None
+
+
+class LicenseGenerationRequestModel(BaseModel):
+    """
+    Model for generating a license key
+    """
+
+    email: str

--- a/flaskr/api/respmodels.py
+++ b/flaskr/api/respmodels.py
@@ -45,3 +45,7 @@ class CoursePlanWithSemestersData(BaseModel):
 
 class CoursePlanWithSemestersResponseModel(ResponseModel):
     data: CoursePlanWithSemestersData | None = None
+
+
+class LicenseKeyResponseModel(ResponseModel):
+    data: str

--- a/flaskr/api/user.py
+++ b/flaskr/api/user.py
@@ -174,6 +174,6 @@ def generate_license(body: LicenseGenerationRequestModel):
         # TODO: To be replaced by an error
         raise DuplicateResource(debug_info="Duplicat email during creation process")
     # TODO: To be replaced by an error
-    return NotFound(
+    raise NotFound(
         debug_info="User attempt to access license generation endpoint while the app is running in production"
     )

--- a/flaskr/api/user.py
+++ b/flaskr/api/user.py
@@ -4,6 +4,7 @@ from flask import Blueprint, session, current_app
 from flask_pydantic import validate  # type: ignore
 
 from flaskr.api import email_service
+from flaskr.api.exceptions import DuplicateResource, NotFound
 from flaskr.api.auth_guard import auth_guard
 from flaskr.api.exceptions import (
     InternalError,
@@ -171,6 +172,8 @@ def generate_license(body: LicenseGenerationRequestModel):
             license_key, _ = create_precreated_user(body.email)
             return LicenseKeyResponseModel(data=license_key)
         # TODO: To be replaced by an error
-        return LicenseKeyResponseModel(data="")
+        raise DuplicateResource(debug_info="Duplicat email during creation process")
     # TODO: To be replaced by an error
-    return LicenseKeyResponseModel(data="")
+    return NotFound(
+        debug_info="User attempt to access license generation endpoint while the app is running in production"
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,6 +51,17 @@ def app():
 
 
 @pytest.fixture
+def debug_app():
+    test_config = {
+        "TESTING": True,
+        "debug": True,
+    }
+    app = create_app(test_config)
+    app.debug = True
+    yield app
+
+
+@pytest.fixture
 def client(app: Flask):
     """
     Provide a test client for the Flask app.
@@ -64,3 +75,8 @@ def client_2(app: Flask):
     Provide another test client for the Flask app.
     """
     return app.test_client()
+
+
+@pytest.fixture
+def debug_client(debug_app: Flask):
+    return debug_app.test_client()

--- a/tests/test_api_user.py
+++ b/tests/test_api_user.py
@@ -424,4 +424,4 @@ def test_license_endpoint_access_in_production(client: FlaskClient):
 
     assert response.status_code == NotFound.status_code
     res = ResponseModel.model_validate(response.json)
-    assert res == "ERROR"
+    assert res.status == "ERROR"


### PR DESCRIPTION
Currently, the license key generation is using a weird python script, which is annoying to setup because it requires poetry install. This license key endpoint will be able to generate license key if the app is running in debug mode

I forced push the branch to remove the commits made in the other branch... Sorry that I branch off from a feature branch...